### PR TITLE
Changing quantifier parser to fail when m > n in {m,n}.

### DIFF
--- a/src/main/scala/com/github/dlomsak/regex/deriv/phase/REParser.scala
+++ b/src/main/scala/com/github/dlomsak/regex/deriv/phase/REParser.scala
@@ -79,10 +79,9 @@ object REParser extends Parsers {
   }
 
 
-  def quantifier: Parser[(Int, Option[Int])] = LBRACE ~> int ~ opt(COMMA) ~ opt(int) <~ RBRACE ^^ {
-    case i ~ Some(_) ~ j   => (i, j)
-    case i ~ None ~ None => (i, Some(i))
+  def quantifier: Parser[(Int, Option[Int])] = LBRACE ~> int ~ opt(COMMA) ~ opt(int) <~ RBRACE flatMap {
+    case i ~ Some(_) ~ j if i <= j.getOrElse(Int.MaxValue)  => success((i, j))
+    case i ~ None ~ None => success((i, Some(i)))
+    case i ~ Some(_) ~ Some(j) => err(s"In quantifier {m,n}, m is $i and n is $j, but m cannot be greater than n.")
   }
-
-
 }

--- a/src/test/scala/com/github/dlomsak/regex/deriv/phase/REParserSpec.scala
+++ b/src/test/scala/com/github/dlomsak/regex/deriv/phase/REParserSpec.scala
@@ -79,7 +79,8 @@ class REParserSpec extends BaseSpec {
     REParser(RELexer("2{-2}").right.get) shouldBe 'Left
   }
 
-  it should "treat {m,n} as {m} if n < m; this will probably change later but for now codifying intended behavior" in {
-    REParser(RELexer("2{5,2}").right.get) shouldBe Right(CatAST(CharAST('2'), CatAST(CharAST('2'), CatAST(CharAST('2'), CatAST(CharAST('2'), CharAST('2'))))))
+  it should "fail when when m is greater than n in {m,n}" in {
+    println(REParser(RELexer("2{5,2}").right.get))
+    REParser(RELexer("2{5,2}").right.get) shouldBe Left(RegexParserError("In quantifier {m,n}, m is 5 and n is 2, but m cannot be greater than n."))
   }
 }


### PR DESCRIPTION
Replaced the quantifier parser action `^^` with `flatMap`, and returning failure when m > n.